### PR TITLE
export node extension artifact

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -51,6 +51,7 @@ node-ext:
   RUN npm install
   COPY globalbrain-node/test.js ./
   RUN node test.js ./test-globalbrain-node.db
+  SAVE ARTIFACT dist
 
 
 


### PR DESCRIPTION
Expose artifacts from the `+node-ext` target, which will be used in the [`Earthfile`](https://github.com/social-protocols/jabble/pull/50/files#diff-2705f6016a64189abd14041e2f3e8dbb829553295d9088e4eb42eccb5e61bf47R64) in jabble.