### PR TITLE
Update flake.lock, migrate flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707743206,
-        "narHash": "sha256-AehgH64b28yKobC/DAWYZWkJBxL/vP83vkY+ag2Hhy4=",
+        "lastModified": 1714656196,
+        "narHash": "sha256-kjQkA98lMcsom6Gbhw8SYzmwrSo+2nruiTcTZp5jK7o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2d627a2a704708673e56346fcb13d25344b8eaf3",
+        "rev": "94035b482d181af0a0f8f77823a790b256b7c3cc",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
           jq
           sqlite-interactive
           julia_19-bin
-          nodejs_21
+          nodejs_22
           python3 # for node-gyp
           gcc
           gnumake
@@ -32,11 +32,9 @@
           clang
           llvmPackages.libcxxStdenv
           llvmPackages.libcxx
-          llvmPackages.libcxxabi
           llvmPackages.clang
           libcxxStdenv
           libcxx
-          libcxxabi
         ];
       in {
         devShells = {


### PR DESCRIPTION
gains:
- not being stuck with an old flake
- latest earthly version, which makes it easier to work locally with other repos

state:
- Node extension compiles and tests run
- simulation fails with sql error, might be easy to fix

