### PR TITLE
error on already seen vote event

### DIFF
--- a/justfile
+++ b/justfile
@@ -48,6 +48,7 @@ ci-test:
 build-shared-library:
     rm -rf globalbrain-node/julia/build
     cd globalbrain-node/julia && julia -t auto --startup-file=no --project -e 'using Pkg; Pkg.instantiate(); include("build.jl")'
+    cd globalbrain-node && npm install && npm test
 
 
 ############ TESTS ##############


### PR DESCRIPTION
- Add npm install && npm test to just build-shared-library
- Throw errors instead of just printing errors in vote-event-processing.jl
