### PR TITLE
fix linking paths to avoid julia installation on callsite, add c tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,5 +25,5 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Test
-      run: earthly --auto-skip +ci-test
+      run: earthly --no-output +ci-test
 

--- a/Earthfile
+++ b/Earthfile
@@ -161,6 +161,7 @@ ci-test:
   BUILD +sim-run
   BUILD +vis-build
   BUILD +vis-format-check
+  BUILD +node-ext-test
 
 ci-deploy:
   BUILD +ci-test

--- a/Earthfile
+++ b/Earthfile
@@ -46,10 +46,13 @@ node-ext:
   # rpath pointed to /nix/store, TODO: report upstream to julia / PackageCompiler
   # To patch a new file, first print the rpath using:
   # RUN patchelf --print-rpath build/lib/julia/<libfile>
-  RUN patchelf --set-rpath '$ORIGIN/..:$ORIGIN' build/lib/julia/libjulia-internal.so.1 \
-   && patchelf --set-rpath '$ORIGIN/..:$ORIGIN' build/lib/julia/libjulia-codegen.so.1.9 \
-   && patchelf --set-rpath '$ORIGIN' build/lib/julia/libgfortran.so.5
-  RUN find build -name '*.so*' -type f -exec bash -c 'echo -n "{}, rpath=" && patchelf --print-rpath {}' \; | sort
+
+  RUN find build | sort
+  RUN patchelf --set-rpath '$ORIGIN/..:$ORIGIN' build/lib/julia/libjulia-internal.so \
+   && patchelf --set-rpath '$ORIGIN/..:$ORIGIN' build/lib/julia/libjulia-codegen.so \
+   && patchelf --set-rpath '$ORIGIN' build/lib/julia/libgfortran.so \
+   && patchelf --set-rpath '$ORIGIN' build/lib/julia/libmbedtls.so 
+  RUN find build -name '*.so*' -type f -exec bash -c 'echo -n "{}, rpath=" && patchelf --print-rpath {} && ldd {}' \;
 
   WORKDIR /app/globalbrain-node
   COPY globalbrain-node/package.json globalbrain-node/package-lock.json ./

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.9.4"
+julia_version = "1.10.3"
 manifest_format = "2.0"
-project_hash = "5d7f1c651582072316957f8b6805384fa29504eb"
+project_hash = "fbb57eeab00ff4f60036615ac58ed950dac31e56"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -13,12 +13,12 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.0.5+0"
+version = "1.1.1+0"
 
 [[deps.DBInterface]]
-git-tree-sha1 = "9b0dc525a052b9269ccc5f7f04d5b3639c65bca5"
+git-tree-sha1 = "a444404b3f94deaa43ca2a58e18153a82695282b"
 uuid = "a10d1c49-ce27-4219-8d33-6db1a4562965"
-version = "2.5.0"
+version = "2.6.1"
 
 [[deps.DataAPI]]
 git-tree-sha1 = "abe83f3a2f1b857aac70ef8b269080af17764bbe"
@@ -93,7 +93,7 @@ uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.21+4"
+version = "0.3.23+4"
 
 [[deps.OrderedCollections]]
 git-tree-sha1 = "dfdf5519f235516220579f949664f1bf44e741c5"
@@ -108,22 +108,22 @@ version = "2.8.1"
 
 [[deps.PrecompileTools]]
 deps = ["Preferences"]
-git-tree-sha1 = "03b4c25b43cb84cee5c90aa9b5ea0a78fd848d2f"
+git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
 uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-version = "1.2.0"
+version = "1.2.1"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "00805cd429dcb4870060ff49ef443486c262e38e"
+git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.4.1"
+version = "1.4.3"
 
 [[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [[deps.Random]]
-deps = ["SHA", "Serialization"]
+deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[deps.SHA]]
@@ -132,15 +132,15 @@ version = "0.7.0"
 
 [[deps.SQLite]]
 deps = ["DBInterface", "Random", "SQLite_jll", "Serialization", "Tables", "WeakRefStrings"]
-git-tree-sha1 = "eb9a473c9b191ced349d04efa612ec9f39c087ea"
+git-tree-sha1 = "38b82dbc52b7db40bea182688c7a1103d06948a4"
 uuid = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
-version = "1.6.0"
+version = "1.6.1"
 
 [[deps.SQLite_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll"]
-git-tree-sha1 = "75e28667a36b5650b5cc4baa266c5760c3672275"
+git-tree-sha1 = "004fffbe2711abdc7263a980bbb1af9620781dd9"
 uuid = "76ed43ae-9a5d-5a62-8c75-30186b810ce8"
-version = "3.45.0+0"
+version = "3.45.3+0"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
@@ -182,9 +182,9 @@ version = "1.4.2"
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.13+0"
+version = "1.2.13+1"
 
 [[deps.libblastrampoline_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
-version = "5.8.0+0"
+version = "5.8.0+1"

--- a/Project.toml
+++ b/Project.toml
@@ -12,4 +12,4 @@ SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-julia = "=1.9.4"
+julia = "=1.10.3"

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
           diffutils
           jq
           pkgs-sqlite.sqlite-interactive
-          julia_19-bin
+          julia-bin
           nodejs_20
           python3 # for node-gyp
           gcc

--- a/globalbrain-node/globalbrain-node-test/test.c
+++ b/globalbrain-node/globalbrain-node-test/test.c
@@ -1,0 +1,36 @@
+#include <stdio.h>
+
+#include "globalbrain.h"
+#include "julia_init.h"
+#include <string.h>
+
+#define BUFFER_SIZE 1024
+
+int main(int argc, char *argv[]) {
+
+  init_julia(argc, argv);
+  char *resultBuffer = process_vote_event_json_c(
+      "test.db",
+      "{\"user_id\":\"100\",\"tag_id\":1,\"parent_id\":null,\"post_id\":1,"
+      "\"note_id\":null,\"vote\":1,\"vote_event_time\":1708772663570,\"vote_"
+      "event_id\":1}");
+  shutdown_julia(0);
+
+  const char *targetResult =
+      "{\"vote_event_id\":1,\"vote_event_time\":1708772663570,\"score\":{\"tag_"
+      "id\":1,\"post_id\":1,\"top_note_id\":null,\"critical_thread_id\":null,"
+      "\"o\":0.9129,\"o_count\":1,"
+      "\"o_size\":1,\"p\":0.9129,\"score\":0.7928}}\n";
+
+  if (strcmp(resultBuffer, targetResult) != 0) {
+    fprintf(stderr,
+            "Error: Result does not match the expected output:\nresult: "
+            "%s\ntarget: %s",
+            resultBuffer, targetResult);
+    return 1;
+  } else {
+    printf("Calling julia function from C successful!");
+  }
+
+  return 0;
+}

--- a/globalbrain-node/globalbrain-node-test/test.cc
+++ b/globalbrain-node/globalbrain-node-test/test.cc
@@ -1,0 +1,36 @@
+#include <stdio.h>
+
+#include "globalbrain.h"
+#include "julia_init.h"
+#include <string.h>
+
+#define BUFFER_SIZE 1024
+
+int main(int argc, char *argv[]) {
+
+  init_julia(argc, argv);
+  char *resultBuffer = process_vote_event_json_c(
+      "test.db",
+      "{\"user_id\":\"100\",\"tag_id\":1,\"parent_id\":null,\"post_id\":1,"
+      "\"note_id\":null,\"vote\":1,\"vote_event_time\":1708772663570,\"vote_"
+      "event_id\":1}");
+  shutdown_julia(0);
+
+  const char *targetResult =
+      "{\"vote_event_id\":1,\"vote_event_time\":1708772663570,\"score\":{\"tag_"
+      "id\":1,\"post_id\":1,\"top_note_id\":null,\"critical_thread_id\":null,"
+      "\"o\":0.9129,\"o_count\":1,"
+      "\"o_size\":1,\"p\":0.9129,\"score\":0.7928}}\n";
+
+  if (strcmp(resultBuffer, targetResult) != 0) {
+    fprintf(stderr,
+            "Error: Result does not match the expected output:\nresult: "
+            "%s\ntarget: %s",
+            resultBuffer, targetResult);
+    return 1;
+  } else {
+    printf("Calling julia function from C++ successful!");
+  }
+
+  return 0;
+}

--- a/globalbrain-node/julia/Manifest.toml
+++ b/globalbrain-node/julia/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.9.4"
+julia_version = "1.10.3"
 manifest_format = "2.0"
-project_hash = "444e95968630163962e90424cbc265491010e9c0"
+project_hash = "eb1eadd486b9ae211eb055beceecba88753577db"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -50,8 +50,13 @@ uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
 version = "8.4.0+0"
 
 [[deps.LibGit2]]
-deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.6.4+0"
 
 [[deps.LibSSH2_jll]]
 deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
@@ -71,11 +76,11 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.2+0"
+version = "2.28.2+1"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2022.10.11"
+version = "2023.1.10"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
@@ -90,7 +95,7 @@ version = "2.1.17"
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.9.2"
+version = "1.10.0"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -101,7 +106,7 @@ deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.Random]]
-deps = ["SHA", "Serialization"]
+deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[deps.RelocatableFolders]]
@@ -146,7 +151,7 @@ uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.13+0"
+version = "1.2.13+1"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -156,4 +161,4 @@ version = "1.52.0+1"
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.4.0+0"
+version = "17.4.0+2"

--- a/globalbrain-node/julia/Project.toml
+++ b/globalbrain-node/julia/Project.toml
@@ -2,4 +2,5 @@
 PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
 
 [compat]
-julia = "=1.9.4"
+julia = "=1.10.3"
+

--- a/globalbrain-node/julia/build.jl
+++ b/globalbrain-node/julia/build.jl
@@ -10,8 +10,8 @@ println("Creating library in $target_dir")
 # https://julialang.github.io/PackageCompiler.jl/stable/refs.html#PackageCompiler.create_library
 PackageCompiler.create_library(globalbrainSourceDir, target_dir;
                                 lib_name="globalbrain",
-                                incremental=false,
-                                filter_stdlibs=true,
+                                incremental=true,
+                                filter_stdlibs=false,
                                 force=true, # Overwrite target_dir.
                                 header_files = ["$(@__DIR__)/globalbrain.h"],
                             )

--- a/globalbrain-node/julia/build.jl
+++ b/globalbrain-node/julia/build.jl
@@ -7,6 +7,7 @@ globalbrainSourceDir = "../.."
 target_dir = "$(@__DIR__)/build"
 
 println("Creating library in $target_dir")
+# https://julialang.github.io/PackageCompiler.jl/stable/refs.html#PackageCompiler.create_library
 PackageCompiler.create_library(globalbrainSourceDir, target_dir;
                                 lib_name="globalbrain",
                                 incremental=false,


### PR DESCRIPTION
The julia build from PackageCompiler actually ships all needed libraries in the bundle. But some of those libraries referred to each other via an absolute path pointing to `/nix/store/...julia.../lib...` . Replacing that with a relative path using `patchelf` solved it. That way, no more julia nix package has to be installed on the callsite. That's actually a bug in either PackageCompiler or the julia nix package.

Learning:
`LD_LIBRARY_PATH` provides paths to search for libraries via env variable, while `rpath` codes those lookup paths into the binary.